### PR TITLE
Add basic music ads API skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/README.md
+++ b/README.md
@@ -1,3 +1,33 @@
-# VITE_SUPABASE
+# Plateforme de promotion musicale
+
+Ce projet propose une base pour une application permettant de lancer des campagnes publicitaires sur **Meta**, **YouTube** et **TikTok** afin de promouvoir le travail d'artistes musiciens. L'objectif est de fournir un outil simple, pratique et intuitif.
+
+Les variables d'environnement nécessaires pour la connexion à Supabase sont indiquées ci-dessous :
+
+```
 VITE_SUPABASE_URL=https://fbjnejkmprnuhqjyagjt.supabase.co
 VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+```
+
+## Installation
+
+1. Installez les dépendances Node.js :
+   ```bash
+   npm install
+   ```
+2. Créez un fichier `.env` à la racine du projet contenant les clés Supabase ci-dessus.
+3. Lancez le serveur :
+   ```bash
+   npm start
+   ```
+
+## Fonctionnement
+
+L'API Express expose deux routes principales :
+
+- `GET /campaigns` : retourne la liste des campagnes enregistrées dans Supabase.
+- `POST /campaigns` : enregistre une nouvelle campagne et appelle la fonction correspondant à la plateforme choisie (`meta`, `youtube` ou `tiktok`).
+
+Les fonctions d'envoi vers les plateformes (`createMetaAdCampaign`, `createYouTubeAdCampaign`, `createTikTokAdCampaign`) sont à implémenter avec les appels aux API publicitaires officielles.
+
+Ce dépôt constitue un point de départ pour bâtir une interface plus complète (par exemple avec React et Vite) permettant de gérer facilement les campagnes des artistes.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "vite_supabase",
+  "version": "1.0.0",
+  "description": "VITE_SUPABASE_URL=https://fbjnejkmprnuhqjyagjt.supabase.co VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "express": "^4.18.2",
+    "supabase-js": "^2.24.0",
+    "cors": "^2.8.5"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,70 @@
+import express from 'express';
+import cors from 'cors';
+import { createClient } from '@supabase/supabase-js';
+
+const { VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY } = process.env;
+
+if (!VITE_SUPABASE_URL || !VITE_SUPABASE_ANON_KEY) {
+  console.error('Missing Supabase environment variables.');
+  process.exit(1);
+}
+
+const supabase = createClient(VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY);
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+app.get('/', (req, res) => {
+  res.send('Music Ads Platform API');
+});
+
+app.get('/campaigns', async (req, res) => {
+  const { data, error } = await supabase.from('campaigns').select('*');
+  if (error) return res.status(500).json({ error: error.message });
+  res.json(data);
+});
+
+app.post('/campaigns', async (req, res) => {
+  const campaign = req.body;
+  const { data, error } = await supabase.from('campaigns').insert(campaign).select('*').single();
+  if (error) return res.status(500).json({ error: error.message });
+  try {
+    await dispatchCampaignToPlatform(campaign);
+  } catch (err) {
+    console.error(err);
+  }
+  res.json(data);
+});
+
+async function dispatchCampaignToPlatform(campaign) {
+  switch (campaign.platform) {
+    case 'meta':
+      return createMetaAdCampaign(campaign);
+    case 'youtube':
+      return createYouTubeAdCampaign(campaign);
+    case 'tiktok':
+      return createTikTokAdCampaign(campaign);
+    default:
+      throw new Error('Unknown platform');
+  }
+}
+
+async function createMetaAdCampaign(campaign) {
+  // TODO: integrate with Meta Marketing API
+  console.log('Sending campaign to Meta:', campaign);
+}
+
+async function createYouTubeAdCampaign(campaign) {
+  // TODO: integrate with Google Ads API for YouTube
+  console.log('Sending campaign to YouTube:', campaign);
+}
+
+async function createTikTokAdCampaign(campaign) {
+  // TODO: integrate with TikTok Ads API
+  console.log('Sending campaign to TikTok:', campaign);
+}
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- initialize npm project and ignore `node_modules`
- add Express API server that stores campaigns in Supabase and stubs integration with Meta/YouTube/TikTok
- document setup steps in French

## Testing
- `node server.js` *(fails: Cannot find package 'express')*
- `npm install express supabase-js` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6863e35dc3e48330848c0501d4c3f84e